### PR TITLE
Put margins on the container_12 div, rather than the grid_## divs, to avo

### DIFF
--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -1,3 +1,7 @@
+.container_12 {
+  margin-left: 0px;
+  margin-right: 0px;
+}
 .grid_1,
 .grid_2,
 .grid_3,
@@ -10,8 +14,8 @@
 .grid_10,
 .grid_11,
 .grid_12 {
-  margin-left: 10px;
-  margin-right: 10px;
+  margin-left: 0px;
+  margin-right: 0px;
 }
 
 .align_center,

--- a/assets/css/mobile.css
+++ b/assets/css/mobile.css
@@ -1,6 +1,6 @@
 .container_12 {
-  margin-left: 0px;
-  margin-right: 0px;
+  margin-left: 10px;
+  margin-right: 10px;
 }
 .grid_1,
 .grid_2,


### PR DESCRIPTION
Put margins on the container_12 div, rather than the grid_## divs, to avoid misalignment in mobile view between alpha/omega columns and standard columns
