### PR TITLE
Set blank url if range is empty

### DIFF
--- a/assets/js/adapt.js
+++ b/assets/js/adapt.js
@@ -60,10 +60,10 @@
     var i = range_len;
     var last = range_len - 1;
 
-    while (i--) {
-      // Blank if no conditions met.
-      url = '';
+    // Blank if no conditions met or range is empty
+    url = '';
 
+    while (i--) {
       // Turn string into array.
       arr = range[i].split('=');
 


### PR DESCRIPTION
Move setting url to blank string outside of loop in case if range is empty array. In case when adapt.js is not configured properly yet it helps to avoid requests to .../undefined address, which often lead to application server routing error.
